### PR TITLE
Fix a FC Error in the logout flow

### DIFF
--- a/Source/WebApp-Service-Provider-DotNet/Controllers/ManageController.cs
+++ b/Source/WebApp-Service-Provider-DotNet/Controllers/ManageController.cs
@@ -255,7 +255,7 @@ namespace WebApp_Service_Provider_DotNet.Controllers
             var info = await _signInManager.GetExternalLoginInfoAsync();
             if (info == null)
             {
-                throw new NotSupportedException("Can not retrive external claims");
+                throw new NotSupportedException("Can not retrieve external claims");
             }
             var claims = info.Principal.Claims;
             var pivotIdentity = new PivotIdentity

--- a/Source/WebApp-Service-Provider-DotNet/Startup.cs
+++ b/Source/WebApp-Service-Provider-DotNet/Startup.cs
@@ -142,10 +142,13 @@ namespace WebApp_Service_Provider_DotNet
 
             //FC refuses unknown parameters in the requests, so the two following options are needed 
             oidc_options.DisableTelemetry = true; //This is false by default on .NET Core 3.1, and sends additional parameters such as "x-client-ver" in the requests to FC.
-            oidc_options.UsePkce = false; //This is true by default on .NET Core 3.1, and sends additional parameters such as "code_challenge" in the requests to FC.
+            oidc_options.UsePkce = false; //This is true by default on .NET Core 3.1, and enables additional parameters such as "code_challenge" in the requests to FC.
+
+            //FC errors out (in the logout flow, with a E000031 undocumented error) when parsing an id token with a dot in the nonce. We use this option so that the nonce does not contain a dot.
+            oidc_options.ProtocolValidator.RequireTimeStampInNonce = false;//https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.protocols.openidconnect.openidconnectprotocolvalidator.requiretimestampinnonce
 
             oidc_options.SaveTokens = true;//This is needed to keep the id_token obtained for authentication : we have to send it back to FC to logout.
-
+            
             oidc_options.ClientId = fcConfig.ClientId;
             oidc_options.ClientSecret = fcConfig.ClientSecret;
             oidc_options.CallbackPath = fcConfig.CallbackPath;

--- a/Source/WebApp-Service-Provider-DotNet/WebApp-Service-Provider-DotNet.csproj
+++ b/Source/WebApp-Service-Provider-DotNet/WebApp-Service-Provider-DotNet.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>WebApp-Service-Provider</AssemblyName>
-    <PackageId>WebApp-Service-Provider</PackageId>
-    <UserSecretsId>aspnet-WebApp_Service_Provider_DotNet-83512670-8c0d-4168-be43-1cf3f98de941</UserSecretsId>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<PreserveCompilationContext>true</PreserveCompilationContext>
+		<AssemblyName>WebApp-Service-Provider</AssemblyName>
+		<PackageId>WebApp-Service-Provider</PackageId>
+		<UserSecretsId>aspnet-WebApp_Service_Provider_DotNet-83512670-8c0d-4168-be43-1cf3f98de941</UserSecretsId>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Update="wwwroot\**\*;Views\**\*;Areas\**\Views">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="wwwroot\**\*;Views\**\*;Areas\**\Views">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</None>
+	</ItemGroup>
 
 
 	<ItemGroup>
@@ -22,8 +22,8 @@
 		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.17" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.17" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.17">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.17" />
 		
@@ -31,13 +31,13 @@
 		<PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" PrivateAssets="All" />
 	</ItemGroup>
-	
-  <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
-    <Exec Command="dotnet tool restore" />
-    <Exec Command="dotnet libman restore" />
-    <Exec Command="npm install" />
-    <Exec Command="gulp clean" />
-    <Exec Command="gulp min" />
-  </Target>
+
+	<Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
+		<Exec Command="dotnet tool restore" />
+		<Exec Command="dotnet libman restore" />
+		<Exec Command="npm install" />
+		<Exec Command="gulp clean" />
+		<Exec Command="gulp min" />
+	</Target>
 
 </Project>


### PR DESCRIPTION
FC returns an undocumented E000031 error when logging out, if the nonce provided when logging in contains some characters such as a dot.

By default, .NET Core generates nonces with dots in it, as specified in the [docs](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.protocols.openidconnect.openidconnectprotocolvalidator.generatenonce). 

This disables this default behavior.