### PR TITLE
Use a local Sqlite database instead of a SQL Server on non-production environments

### DIFF
--- a/Source/WebApp-Service-Provider-DotNet/Startup.cs
+++ b/Source/WebApp-Service-Provider-DotNet/Startup.cs
@@ -76,7 +76,7 @@ namespace WebApp_Service_Provider_DotNet
                     }
                     else
                     {
-                        // Sqlite is suggested for development environment, as the database is thus hosted on the filesystem instead of a server.
+                        // Sqlite is suggested for development environments, as the database is thus hosted on the filesystem instead of a server.
                         options.UseSqlite(Configuration.GetConnectionString("SqliteConnection"));
                     }
                 });

--- a/Source/WebApp-Service-Provider-DotNet/Startup.cs
+++ b/Source/WebApp-Service-Provider-DotNet/Startup.cs
@@ -76,6 +76,7 @@ namespace WebApp_Service_Provider_DotNet
                     }
                     else
                     {
+                        // Sqlite is suggested for development environment, as the database is thus hosted on the filesystem instead of a server.
                         options.UseSqlite(Configuration.GetConnectionString("SqliteConnection"));
                     }
                 });
@@ -87,7 +88,7 @@ namespace WebApp_Service_Provider_DotNet
             // Add configuration
             services.AddOptions();
 
-            //Since chromium updates to SameSite cookie policies, this must be used for the authentication cookies to avoid a Correlation error without HTTPS
+            // Since chromium updates to SameSite cookie policies, this must be used for the authentication cookies to avoid a Correlation error without HTTPS
             services.Configure<CookiePolicyOptions>(options =>
             {
                 options.MinimumSameSitePolicy = SameSiteMode.Lax;
@@ -127,7 +128,7 @@ namespace WebApp_Service_Provider_DotNet
 
                 // Apply any pending database migrations on startup (includes initial db creation)
                 dbContext.Database.Migrate();
-                //Not recommended for production databases. See https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/applying#apply-migrations-at-runtime
+                // This is not recommended for production databases. See https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/applying#apply-migrations-at-runtime
             }
 
             app.UseRequestLocalization(new RequestLocalizationOptions { DefaultRequestCulture = new RequestCulture("fr-FR") });

--- a/Source/WebApp-Service-Provider-DotNet/WebApp-Service-Provider-DotNet.csproj
+++ b/Source/WebApp-Service-Provider-DotNet/WebApp-Service-Provider-DotNet.csproj
@@ -20,6 +20,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.17" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.17" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.17" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.17" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.17" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.17">
 			<PrivateAssets>all</PrivateAssets>

--- a/Source/WebApp-Service-Provider-DotNet/appsettings.Development.json
+++ b/Source/WebApp-Service-Provider-DotNet/appsettings.Development.json
@@ -1,5 +1,6 @@
 ﻿{
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnetcore-WebApp_Service_Provider_DotNet;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnetcore-WebApp_Service_Provider_DotNet;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "SqliteConnection": "DataSource=app.db"
   }
 }


### PR DESCRIPTION
As a sqlite database is saved in the filesystem, this lowers the cost of development/demo environments.