### PR TITLE
Replace Sqlite with an InMemoryDatabase for non production environments

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -53,9 +53,8 @@ jobs:
         publish-profile: ${{ env.AZURE_WEBAPP_PUBLISH_PROFILE }}
         
     - name: Apply database migrations
-      if: ${{ steps.deploy.conclusion == 'success' }}
-      run: dotnet ef database update
-      working-directory: ${{ env.WORKING_DIRECTORY }}
+      if: ${{ steps.deploy.conclusion == 'success' && env.CONFIGURATION == 'Production' }}
+      run: dotnet ef database update --project ${{ env.WORKING_DIRECTORY }}"
       env:
           FRANCECONNECT__CLIENTSECRET: "Dummy value in order for the project to pass startup checks"
           ASPNETCORE_ENVIRONMENT: ${{ env.CONFIGURATION }}

--- a/Source/WebApp-Service-Provider-DotNet/Startup.cs
+++ b/Source/WebApp-Service-Provider-DotNet/Startup.cs
@@ -76,8 +76,8 @@ namespace WebApp_Service_Provider_DotNet
                     }
                     else
                     {
-                        // Sqlite is suggested for development environments, as the database is thus hosted on the filesystem instead of a server.
-                        options.UseSqlite(Configuration.GetConnectionString("SqliteConnection"));
+                        // Suggested for development environments, as the database is thus hosted with the web app instead of a separate server.
+                        options.UseInMemoryDatabase("InMemory");
                     }
                 });
 
@@ -125,10 +125,6 @@ namespace WebApp_Service_Provider_DotNet
                 app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
                 app.UseDatabaseErrorPage();
-
-                // Apply any pending database migrations on startup (includes initial db creation)
-                dbContext.Database.Migrate();
-                // This is not recommended for production databases. See https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/applying#apply-migrations-at-runtime
             }
 
             app.UseRequestLocalization(new RequestLocalizationOptions { DefaultRequestCulture = new RequestCulture("fr-FR") });

--- a/Source/WebApp-Service-Provider-DotNet/WebApp-Service-Provider-DotNet.csproj
+++ b/Source/WebApp-Service-Provider-DotNet/WebApp-Service-Provider-DotNet.csproj
@@ -20,7 +20,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.17" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.17" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.17" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.17" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.17" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.17" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.17">
 			<PrivateAssets>all</PrivateAssets>

--- a/Source/WebApp-Service-Provider-DotNet/appsettings.Development.json
+++ b/Source/WebApp-Service-Provider-DotNet/appsettings.Development.json
@@ -1,6 +1,5 @@
 ﻿{
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnetcore-WebApp_Service_Provider_DotNet;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "SqliteConnection": "DataSource=app.db"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnetcore-WebApp_Service_Provider_DotNet;Trusted_Connection=True;MultipleActiveResultSets=true"
   }
 }


### PR DESCRIPTION
Because Azure linux environments seems to have an ongoing issue with sqlite databases. [Relevant stackoverflow](https://stackoverflow.com/questions/53226642/sqlite3-database-is-locked-in-azure)