### PR TITLE
Migrate to .NET 5

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,7 +15,7 @@ env:
   CONNECTIONSTRINGS__DEFAULTCONNECTION: ${{ secrets.database_connection_string }}
   CONFIGURATION: Debug
   ASPNETCORE_ENVIRONMENT: Development
-  DOTNET_CORE_VERSION: 3.1.x
+  DOTNET_CORE_VERSION: 5.0.x
   WORKING_DIRECTORY: Source/WebApp-Service-Provider-DotNet/
 jobs:
   build-and-deploy:

--- a/Source/WebApp-Service-Provider-DotNet/Startup.cs
+++ b/Source/WebApp-Service-Provider-DotNet/Startup.cs
@@ -71,6 +71,7 @@ namespace WebApp_Service_Provider_DotNet
                         options.UseInMemoryDatabase("InMemory");
                     }
                 });
+            services.AddDatabaseDeveloperPageExceptionFilter();
 
             services.AddIdentity<ApplicationUser, IdentityRole>()
                 .AddEntityFrameworkStores<ApplicationDbContext>()
@@ -99,7 +100,7 @@ namespace WebApp_Service_Provider_DotNet
             {
                 app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
-                app.UseDatabaseErrorPage();
+                app.UseMigrationsEndPoint();
             }
 
             // Disable HTTPS when using the default FC credentials, as these are only configured for http URLs

--- a/Source/WebApp-Service-Provider-DotNet/WebApp-Service-Provider-DotNet.csproj
+++ b/Source/WebApp-Service-Provider-DotNet/WebApp-Service-Provider-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
 		<AssemblyName>WebApp-Service-Provider</AssemblyName>
 		<PackageId>WebApp-Service-Provider</PackageId>
@@ -16,20 +16,20 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.17" />
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.17" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.17" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.17" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.17" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.17">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.10" />
+		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.10" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.10">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.17" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
 		
 		<PackageReference Include="IdentityModel" Version="5.1.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" PrivateAssets="All" />
 	</ItemGroup>
 
 	<Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">


### PR DESCRIPTION
Migrate project & dependencies to .NET 5, and migrate newly deprecated methods.

Github Actions now use .NET 5 as well.