### PR TITLE
Fix a bug when attempting to view an unauthorized page

### DIFF
--- a/Source/WebApp-Service-Provider-DotNet/Startup.cs
+++ b/Source/WebApp-Service-Provider-DotNet/Startup.cs
@@ -78,11 +78,7 @@ namespace WebApp_Service_Provider_DotNet
                 .AddSignInManager<FCSignInManager>()
                 .AddClaimsPrincipalFactory<ApplicationUserClaimsPrincipalFactory>();
 
-            services.AddAuthentication(
-                options =>
-                {
-                    options.DefaultChallengeScheme = FranceConnectConfiguration.ProviderScheme;
-                })
+            services.AddAuthentication()
                 .AddOpenIdConnect(FranceConnectConfiguration.ProviderScheme, FranceConnectConfiguration.ProviderDisplayName, options => ConfigureFranceConnect(options, franceConnectConfig.Get<FranceConnectConfiguration>()));
 
             services.AddControllersWithViews();


### PR DESCRIPTION
If the user was not logged in, they were being redirected to FranceConnect directly, instead of having the choice between local login & FranceConnect.